### PR TITLE
M1 Group B: Benchmark domain models

### DIFF
--- a/src/benchmark/domain/models.py
+++ b/src/benchmark/domain/models.py
@@ -1,0 +1,76 @@
+"""Domain models for the NRC benchmark generation pipeline.
+
+All models are frozen dataclasses. Identity (``unit_id``) is structurally
+derived in Stage 1a and immutable from that point forward.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from benchmark.domain.enums import UnitKind
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkSourceSpan:
+    """Stage 0 output: a benchmark-friendly view over a corpus span.
+
+    Maps one ``(section, subsection_chain)`` pair from ``ecfr_parser``
+    to the benchmark's evidence coordinate system.
+    """
+
+    source_doc_id: str
+    citation: str  # e.g. "10 CFR 50.46(b)(1)"
+    citation_key: str  # stable key for dedup/linking
+    section_title: str
+    text: str
+    char_start: int
+    char_end: int
+    chunk_ids_overlapping_span: tuple[str, ...]
+    parent_section_id: str  # ParsedSection.section_number, e.g. "50.46"
+    effective_date: str  # ISO date string
+    corpus_snapshot_id: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class RegulatoryUnit:
+    """Stage 1a output: a stable regulatory unit with immutable identity.
+
+    ``unit_id`` is minted from the subsection chain (e.g.
+    ``50.46_b_1_peak_cladding_temp``) and never changes after Stage 1a.
+    """
+
+    unit_id: str
+    kind: UnitKind
+    spans: tuple[BenchmarkSourceSpan, ...]
+    citation: str
+    subsection_chain: tuple[str, ...]
+    parent_section_id: str
+    corpus_snapshot_id: str
+
+    # Populated by Stage 1b (LLM classification) — left as defaults in M1.
+    canonical_statement: str | None = None
+    entities: tuple[str, ...] = ()
+    value: str | None = None  # numeric threshold if present
+    conditions: tuple[str, ...] = ()
+
+    # Populated by Stage 1a when paragraphs contain cross-references.
+    cross_references: tuple[str, ...] = ()  # target_citation values
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class StageConfig:
+    """Per-stage configuration for the benchmark pipeline.
+
+    Deterministic by default (``temperature=0.0``) for reproducibility.
+    """
+
+    model: str
+    temperature: float = 0.0
+    max_tokens: int = 4096
+    max_retries: int = 3
+    timeout_s: float = 60.0

--- a/tests/benchmark/domain/test_models.py
+++ b/tests/benchmark/domain/test_models.py
@@ -1,0 +1,115 @@
+# tests/benchmark/domain/test_models.py
+"""Tests for benchmark domain models."""
+
+from __future__ import annotations
+
+import dataclasses
+
+from benchmark.domain.enums import UnitKind
+from benchmark.domain.models import BenchmarkSourceSpan, RegulatoryUnit, StageConfig
+
+
+class TestBenchmarkSourceSpan:
+    def test_frozen(self) -> None:
+        span = BenchmarkSourceSpan(
+            source_doc_id="doc_1",
+            citation="10 CFR 50.46(b)(1)",
+            citation_key="10_cfr_50.46_b_1",
+            section_title="Acceptance criteria for ECCS",
+            text="Peak cladding temperature shall not exceed 2200°F.",
+            char_start=0,
+            char_end=51,
+            chunk_ids_overlapping_span=("chunk_17",),
+            parent_section_id="50.46",
+            effective_date="2026-01-01",
+            corpus_snapshot_id="abc123",
+        )
+        assert dataclasses.is_dataclass(span)
+        with_error = False
+        try:
+            span.text = "mutated"  # type: ignore[misc]
+        except dataclasses.FrozenInstanceError:
+            with_error = True
+        assert with_error
+
+    def test_defaults(self) -> None:
+        span = BenchmarkSourceSpan(
+            source_doc_id="doc_1",
+            citation="10 CFR 50.46(b)(1)",
+            citation_key="10_cfr_50.46_b_1",
+            section_title="Acceptance criteria",
+            text="Some text.",
+            char_start=0,
+            char_end=10,
+            chunk_ids_overlapping_span=(),
+            parent_section_id="50.46",
+            effective_date="2026-01-01",
+            corpus_snapshot_id="abc123",
+        )
+        assert span.metadata == {}
+
+
+class TestRegulatoryUnit:
+    def test_frozen(self) -> None:
+        span = BenchmarkSourceSpan(
+            source_doc_id="doc_1",
+            citation="10 CFR 50.46(b)(1)",
+            citation_key="10_cfr_50.46_b_1",
+            section_title="ECCS criteria",
+            text="Temperature limit.",
+            char_start=0,
+            char_end=18,
+            chunk_ids_overlapping_span=("c1",),
+            parent_section_id="50.46",
+            effective_date="2026-01-01",
+            corpus_snapshot_id="snap1",
+        )
+        unit = RegulatoryUnit(
+            unit_id="50.46_b_1_peak_cladding_temp",
+            kind=UnitKind.THRESHOLD,
+            spans=(span,),
+            citation="10 CFR 50.46(b)(1)",
+            subsection_chain=("b", "1"),
+            parent_section_id="50.46",
+            corpus_snapshot_id="snap1",
+        )
+        assert dataclasses.is_dataclass(unit)
+        assert unit.unit_id == "50.46_b_1_peak_cladding_temp"
+
+    def test_defaults(self) -> None:
+        span = BenchmarkSourceSpan(
+            source_doc_id="doc_1",
+            citation="10 CFR 50.46(b)(1)",
+            citation_key="key",
+            section_title="Title",
+            text="Text.",
+            char_start=0,
+            char_end=5,
+            chunk_ids_overlapping_span=(),
+            parent_section_id="50.46",
+            effective_date="2026-01-01",
+            corpus_snapshot_id="snap1",
+        )
+        unit = RegulatoryUnit(
+            unit_id="50.46_b_1",
+            kind=UnitKind.OBLIGATION,
+            spans=(span,),
+            citation="10 CFR 50.46(b)(1)",
+            subsection_chain=("b", "1"),
+            parent_section_id="50.46",
+            corpus_snapshot_id="snap1",
+        )
+        assert unit.cross_references == ()
+        assert unit.canonical_statement is None
+        assert unit.entities == ()
+        assert unit.conditions == ()
+        assert unit.metadata == {}
+
+
+class TestStageConfig:
+    def test_defaults(self) -> None:
+        cfg = StageConfig(model="gpt-4o")
+        assert cfg.temperature == 0.0
+        assert cfg.max_tokens == 4096
+        assert cfg.max_retries == 3
+        assert cfg.timeout_s == 60.0


### PR DESCRIPTION
## Summary
- Add frozen dataclass domain models: `BenchmarkSourceSpan`, `RegulatoryUnit`, `StageConfig`
- `BenchmarkSourceSpan` is the Stage 0 output — a benchmark-friendly view over corpus spans
- `RegulatoryUnit` is the Stage 1a output — a stable unit with immutable `unit_id`
- `StageConfig` controls per-stage LLM parameters (used in later milestones)

Closes #12

Part of #10

## Test plan
- [x] 5 new tests in `tests/benchmark/domain/test_models.py`
- [x] All 22 benchmark tests passing
- [x] Frozen dataclass invariants verified (mutation raises `FrozenInstanceError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)