### PR TITLE
M1 Group D: Lint, typecheck, and full test pass

### DIFF
--- a/tests/benchmark/stages/test_stage_0_source_view.py
+++ b/tests/benchmark/stages/test_stage_0_source_view.py
@@ -3,12 +3,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 from benchmark.stages.stage_0_source_view import build_source_spans
-
 from rag.adapters.ingestion.regulatory.ecfr_parser import (
-    CrossRef,
     ParsedParagraph,
     ParsedSection,
 )


### PR DESCRIPTION
## Summary
- Remove unused imports in `test_stage_0_source_view.py` (auto-fixed by ruff)
- mypy clean: 0 issues across 12 source files in `src/benchmark/`
- Full test suite: 868 passed, 7 skipped, 0 failures

Closes #16

Part of #10

## Test plan
- [x] `make lint` — clean (5 auto-fixed issues)
- [x] `mypy src/benchmark` — 0 issues, 12 files
- [x] `make test` — 868 passed, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)