### PR TITLE
M3 Group A: Query-stage domain models, ports, and runbook

### DIFF
--- a/docs/operations/benchmark-pipeline-runbook.md
+++ b/docs/operations/benchmark-pipeline-runbook.md
@@ -1,0 +1,140 @@
+# Benchmark Generation Pipeline — Runbook
+
+Operational guide for running the NRC benchmark generation pipeline.
+
+## Prerequisites
+
+- Python 3.11+ environment with `.[dev]` extras installed
+- OpenAI API key in `.env` or `OPENAI_API_KEY` environment variable
+- Parsed eCFR corpus available (run `make index` first if needed)
+- Sufficient API quota for LLM stages (see Cost Estimation below)
+
+## Running a Full Pipeline
+
+```bash
+./scripts/py -m benchmark.pipeline.runner \
+  --run-id "run_$(date +%Y%m%d_%H%M%S)" \
+  --output-dir benchmark_runs/ \
+  --model gpt-4o
+```
+
+### Output Directory Structure
+
+```
+benchmark_runs/<run_id>/
+├── run_config.json              # Pipeline config snapshot
+├── stage_0_spans.jsonl          # BenchmarkSourceSpan records
+├── stage_1a_units.jsonl         # RegulatoryUnit (structural)
+├── stage_1b_classified.jsonl    # RegulatoryUnit (LLM-enriched)
+├── stage_2_evidence.jsonl       # EvidenceSet records
+├── stage_3_candidates.jsonl     # QueryCandidate records
+└── stage_5a_validated.jsonl     # ValidationResult records
+```
+
+## Checkpoint Files
+
+Each stage writes a JSONL checkpoint on completion. One JSON object per
+line, serialized via `dataclasses.asdict()`.
+
+| File | Contains | Typical Size |
+|------|----------|-------------|
+| `stage_0_spans.jsonl` | `BenchmarkSourceSpan` records from corpus | Hundreds |
+| `stage_1a_units.jsonl` | `RegulatoryUnit` records (structural) | Tens–hundreds |
+| `stage_1b_classified.jsonl` | `RegulatoryUnit` records (LLM-enriched) | Same count as 1a |
+| `stage_2_evidence.jsonl` | `EvidenceSet` records per unit | One per unit |
+| `stage_3_candidates.jsonl` | `QueryCandidate` records | 2–5 per unit |
+| `stage_5a_validated.jsonl` | `ValidationResult` records | One per candidate |
+
+### Inspecting Checkpoints
+
+```bash
+# Count records in a checkpoint
+wc -l benchmark_runs/<run_id>/stage_3_candidates.jsonl
+
+# Pretty-print the first record
+head -1 benchmark_runs/<run_id>/stage_3_candidates.jsonl | python3 -m json.tool
+
+# Filter candidates by query class
+./scripts/py -c "
+import json, sys
+for line in open(sys.argv[1]):
+    rec = json.loads(line)
+    if rec['query_class'] == 'citation_lookup':
+        print(rec['query'])
+" benchmark_runs/<run_id>/stage_3_candidates.jsonl
+```
+
+## Resuming a Run
+
+If a run is interrupted or you want to re-run from a specific stage:
+
+```bash
+./scripts/py -m benchmark.pipeline.runner \
+  --run-id "<existing_run_id>" \
+  --output-dir benchmark_runs/ \
+  --resume-from stage_3 \
+  --model gpt-4o
+```
+
+This reads `stage_2_evidence.jsonl` as input and re-runs Stage 3 onward.
+
+| `--resume-from` | Reads checkpoint | Re-runs |
+|-----------------|-----------------|---------|
+| `stage_1a` | `stage_0_spans.jsonl` | 1a → 1b → 2 → 3 → 5a |
+| `stage_1b` | `stage_1a_units.jsonl` | 1b → 2 → 3 → 5a |
+| `stage_2` | `stage_1b_classified.jsonl` | 2 → 3 → 5a |
+| `stage_3` | `stage_2_evidence.jsonl` | 3 → 5a |
+| `stage_5a` | `stage_3_candidates.jsonl` | 5a only |
+
+## Cost Estimation
+
+Approximate LLM API calls per stage at v1 target scale (~50 regulatory
+units):
+
+| Stage | LLM Calls | Notes |
+|-------|-----------|-------|
+| Stage 0 (source view) | 0 | Deterministic |
+| Stage 1a (structural) | 0 | Deterministic |
+| Stage 1b (classification) | ~50 | One per unit |
+| Stage 2 (evidence) | ~50 | One per unit |
+| Stage 3 (query gen) | ~50 | One per unit (citation_lookup only in M3) |
+| Stage 5a (validation) | 0 | Deterministic |
+| **Total** | **~150** | |
+
+At typical GPT-4o pricing, a full run costs roughly $1–3 depending on
+unit text length.
+
+## Troubleshooting
+
+### Snapshot Mismatch
+
+```
+ValueError: Corpus snapshot mismatch: expected 'abc123', got 'def456'
+```
+
+The pipeline's `corpus_snapshot_id` config doesn't match what Stage 0
+produced. Either re-index the corpus or update the config to match.
+
+### Missing Port
+
+```
+ValueError: Stage 3 requires a QueryGenerator but none was provided
+```
+
+A stage was reached that requires a port not passed to `PipelineRunner`.
+Check that all required adapters are wired in the runner construction.
+
+### Malformed Checkpoint
+
+```
+json.JSONDecodeError: Expecting value: line 47 column 1
+```
+
+A checkpoint file was corrupted (partial write during interruption).
+Delete the corrupted file and resume from the prior stage:
+
+```bash
+rm benchmark_runs/<run_id>/stage_3_candidates.jsonl
+./scripts/py -m benchmark.pipeline.runner \
+  --run-id "<run_id>" --output-dir benchmark_runs/ --resume-from stage_3
+```

--- a/src/benchmark/domain/models.py
+++ b/src/benchmark/domain/models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from benchmark.domain.enums import EvidenceTier, UnitKind
+from benchmark.domain.enums import EvidenceTier, QueryClass, UnitKind
 
 
 @dataclass(frozen=True, slots=True)
@@ -107,3 +107,56 @@ class StageConfig:
     max_tokens: int = 4096
     max_retries: int = 3
     timeout_s: float = 60.0
+
+
+@dataclass(frozen=True, slots=True)
+class QueryCandidate:
+    """Stage 3 output: a generated query candidate.
+
+    Produced by a ``QueryGenerator`` from a ``RegulatoryUnit`` and its
+    ``EvidenceSet``.  The ``candidate_id`` is minted by the generator
+    (e.g. ``qc_50.46_b_1_citation_lookup_0``).
+    """
+
+    candidate_id: str
+    unit_id: str
+    query: str
+    query_class: QueryClass
+    source_citations: tuple[str, ...]
+    evidence_span_ids: tuple[str, ...]
+    difficulty: str = "easy"
+    corpus_snapshot_id: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationResult:
+    """Stage 5a output: result of validating a ``QueryCandidate``.
+
+    ``is_valid`` is ``True`` only when ``flags`` is empty.
+    """
+
+    candidate_id: str
+    is_valid: bool
+    flags: tuple[str, ...]
+    scores: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedQuery:
+    """A ``QueryCandidate`` that has passed validation.
+
+    Shares common field names with ``QueryCandidate`` so conversion is
+    straightforward via dict unpacking.
+    """
+
+    candidate_id: str
+    unit_id: str
+    query: str
+    query_class: QueryClass
+    source_citations: tuple[str, ...]
+    evidence_span_ids: tuple[str, ...]
+    difficulty: str
+    corpus_snapshot_id: str
+    validation_scores: dict[str, float] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/src/benchmark/ports/query_generator.py
+++ b/src/benchmark/ports/query_generator.py
@@ -1,0 +1,26 @@
+"""Port protocol for Stage 3 query generation."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from benchmark.domain.enums import QueryClass
+from benchmark.domain.models import EvidenceSet, QueryCandidate, RegulatoryUnit
+
+
+@runtime_checkable
+class QueryGenerator(Protocol):
+    """Generate query candidates from a regulatory unit.
+
+    The ``evidence`` parameter is included alongside the unit because
+    generators need to reference critical spans to construct answerable
+    questions.  This is an intentional deviation from the design doc's
+    ``generate(unit, query_class)`` signature.
+    """
+
+    def generate(
+        self,
+        unit: RegulatoryUnit,
+        evidence: EvidenceSet,
+        query_class: QueryClass,
+    ) -> list[QueryCandidate]: ...

--- a/src/benchmark/ports/query_validator.py
+++ b/src/benchmark/ports/query_validator.py
@@ -1,0 +1,31 @@
+"""Port protocol for Stage 5a query validation."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from benchmark.domain.models import (
+    EvidenceSet,
+    QueryCandidate,
+    ValidatedQuery,
+    ValidationResult,
+)
+
+
+@runtime_checkable
+class QueryValidator(Protocol):
+    """Validate query candidates and optionally refine evidence.
+
+    ``validate`` checks a candidate and returns a ``ValidationResult``.
+    ``refine_evidence`` narrows an ``EvidenceSet`` for a specific validated
+    query — the M3 deterministic adapter returns evidence unchanged, but
+    the M4 LLM adapter will implement per-query refinement.
+    """
+
+    def validate(self, candidate: QueryCandidate) -> ValidationResult: ...
+
+    def refine_evidence(
+        self,
+        query: ValidatedQuery,
+        evidence: EvidenceSet,
+    ) -> EvidenceSet: ...

--- a/tests/benchmark/domain/test_models.py
+++ b/tests/benchmark/domain/test_models.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 
 import dataclasses
 
-from benchmark.domain.enums import EvidenceTier, UnitKind
+from benchmark.domain.enums import EvidenceTier, QueryClass, UnitKind
 from benchmark.domain.models import (
     BenchmarkSourceSpan,
     EvidenceEntry,
     EvidenceSet,
+    QueryCandidate,
     RegulatoryUnit,
     StageConfig,
+    ValidatedQuery,
+    ValidationResult,
 )
 
 
@@ -200,3 +203,135 @@ class TestStageConfig:
         assert cfg.max_tokens == 4096
         assert cfg.max_retries == 3
         assert cfg.timeout_s == 60.0
+
+
+class TestQueryCandidate:
+    def test_frozen(self) -> None:
+        qc = QueryCandidate(
+            candidate_id="qc_50.46_b_1_citation_lookup_0",
+            unit_id="50.46_b_1",
+            query="What does 10 CFR 50.46(b)(1) require?",
+            query_class=QueryClass.CITATION_LOOKUP,
+            source_citations=("10 CFR 50.46(b)(1)",),
+            evidence_span_ids=("50.46_b_1_0",),
+        )
+        assert dataclasses.is_dataclass(qc)
+        with_error = False
+        try:
+            qc.query = "mutated"  # type: ignore[misc]
+        except dataclasses.FrozenInstanceError:
+            with_error = True
+        assert with_error
+
+    def test_defaults(self) -> None:
+        qc = QueryCandidate(
+            candidate_id="qc_1",
+            unit_id="u1",
+            query="Test query?",
+            query_class=QueryClass.CITATION_LOOKUP,
+            source_citations=("10 CFR 50.46",),
+            evidence_span_ids=("u1_0",),
+        )
+        assert qc.difficulty == "easy"
+        assert qc.corpus_snapshot_id == ""
+        assert qc.metadata == {}
+
+    def test_all_query_classes_accepted(self) -> None:
+        for qclass in QueryClass:
+            qc = QueryCandidate(
+                candidate_id=f"qc_{qclass.value}",
+                unit_id="u1",
+                query="Test?",
+                query_class=qclass,
+                source_citations=(),
+                evidence_span_ids=(),
+            )
+            assert qc.query_class == qclass
+
+
+class TestValidationResult:
+    def test_frozen(self) -> None:
+        vr = ValidationResult(
+            candidate_id="qc_1",
+            is_valid=True,
+            flags=(),
+        )
+        assert dataclasses.is_dataclass(vr)
+        with_error = False
+        try:
+            vr.is_valid = False  # type: ignore[misc]
+        except dataclasses.FrozenInstanceError:
+            with_error = True
+        assert with_error
+
+    def test_defaults(self) -> None:
+        vr = ValidationResult(
+            candidate_id="qc_1",
+            is_valid=False,
+            flags=("too_short",),
+        )
+        assert vr.scores == {}
+
+    def test_with_flags_and_scores(self) -> None:
+        vr = ValidationResult(
+            candidate_id="qc_1",
+            is_valid=False,
+            flags=("no_citation", "too_short"),
+            scores={"length_score": 0.3},
+        )
+        assert len(vr.flags) == 2
+        assert vr.scores["length_score"] == 0.3
+
+
+class TestValidatedQuery:
+    def test_frozen(self) -> None:
+        vq = ValidatedQuery(
+            candidate_id="qc_1",
+            unit_id="u1",
+            query="What does 10 CFR 50.46(b)(1) require?",
+            query_class=QueryClass.CITATION_LOOKUP,
+            source_citations=("10 CFR 50.46(b)(1)",),
+            evidence_span_ids=("u1_0",),
+            difficulty="easy",
+            corpus_snapshot_id="snap1",
+        )
+        assert dataclasses.is_dataclass(vq)
+        with_error = False
+        try:
+            vq.query = "mutated"  # type: ignore[misc]
+        except dataclasses.FrozenInstanceError:
+            with_error = True
+        assert with_error
+
+    def test_defaults(self) -> None:
+        vq = ValidatedQuery(
+            candidate_id="qc_1",
+            unit_id="u1",
+            query="Test?",
+            query_class=QueryClass.CITATION_LOOKUP,
+            source_citations=(),
+            evidence_span_ids=(),
+            difficulty="easy",
+            corpus_snapshot_id="snap1",
+        )
+        assert vq.validation_scores == {}
+        assert vq.metadata == {}
+
+    def test_shares_fields_with_query_candidate(self) -> None:
+        """Common fields between QueryCandidate and ValidatedQuery
+        should have the same names for easy conversion."""
+        qc_fields = {f.name for f in dataclasses.fields(QueryCandidate)}
+        vq_fields = {f.name for f in dataclasses.fields(ValidatedQuery)}
+        common = {
+            "candidate_id",
+            "unit_id",
+            "query",
+            "query_class",
+            "source_citations",
+            "evidence_span_ids",
+            "difficulty",
+            "corpus_snapshot_id",
+            "metadata",
+        }
+        assert common <= qc_fields
+        assert common <= vq_fields

--- a/tests/benchmark/ports/test_query_generator.py
+++ b/tests/benchmark/ports/test_query_generator.py
@@ -1,0 +1,78 @@
+"""Tests for the QueryGenerator port protocol."""
+
+from __future__ import annotations
+
+from benchmark.domain.enums import QueryClass, UnitKind
+from benchmark.domain.models import (
+    BenchmarkSourceSpan,
+    EvidenceSet,
+    QueryCandidate,
+    RegulatoryUnit,
+)
+from benchmark.ports.query_generator import QueryGenerator
+
+
+def _make_span() -> BenchmarkSourceSpan:
+    return BenchmarkSourceSpan(
+        source_doc_id="doc_1",
+        citation="10 CFR 50.46(b)(1)",
+        citation_key="10_cfr_50.46_b_1",
+        section_title="ECCS criteria",
+        text="Peak cladding temperature.",
+        char_start=0,
+        char_end=26,
+        chunk_ids_overlapping_span=("c1",),
+        parent_section_id="50.46",
+        effective_date="2026-01-01",
+        corpus_snapshot_id="snap1",
+    )
+
+
+def _make_unit() -> RegulatoryUnit:
+    return RegulatoryUnit(
+        unit_id="50.46_b_1",
+        kind=UnitKind.OBLIGATION,
+        spans=(_make_span(),),
+        citation="10 CFR 50.46(b)(1)",
+        subsection_chain=("b", "1"),
+        parent_section_id="50.46",
+        corpus_snapshot_id="snap1",
+    )
+
+
+class _MockQueryGenerator:
+    """Mock satisfying the QueryGenerator protocol."""
+
+    def generate(
+        self,
+        unit: RegulatoryUnit,
+        evidence: EvidenceSet,
+        query_class: QueryClass,
+    ) -> list[QueryCandidate]:
+        return [
+            QueryCandidate(
+                candidate_id=f"qc_{unit.unit_id}_{query_class.value}_0",
+                unit_id=unit.unit_id,
+                query="What does 10 CFR 50.46(b)(1) require?",
+                query_class=query_class,
+                source_citations=(unit.citation,),
+                evidence_span_ids=tuple(
+                    e.span_id for e in evidence.critical
+                ),
+            )
+        ]
+
+
+class TestQueryGeneratorProtocol:
+    def test_isinstance_check(self) -> None:
+        gen = _MockQueryGenerator()
+        assert isinstance(gen, QueryGenerator)
+
+    def test_generate_returns_candidates(self) -> None:
+        gen = _MockQueryGenerator()
+        unit = _make_unit()
+        evidence = EvidenceSet(unit_id=unit.unit_id)
+        result = gen.generate(unit, evidence, QueryClass.CITATION_LOOKUP)
+        assert len(result) == 1
+        assert result[0].query_class == QueryClass.CITATION_LOOKUP
+        assert result[0].unit_id == unit.unit_id

--- a/tests/benchmark/ports/test_query_validator.py
+++ b/tests/benchmark/ports/test_query_validator.py
@@ -1,0 +1,66 @@
+"""Tests for the QueryValidator port protocol."""
+
+from __future__ import annotations
+
+from benchmark.domain.enums import QueryClass
+from benchmark.domain.models import (
+    EvidenceSet,
+    QueryCandidate,
+    ValidatedQuery,
+    ValidationResult,
+)
+from benchmark.ports.query_validator import QueryValidator
+
+
+class _MockQueryValidator:
+    """Mock satisfying the QueryValidator protocol."""
+
+    def validate(self, candidate: QueryCandidate) -> ValidationResult:
+        return ValidationResult(
+            candidate_id=candidate.candidate_id,
+            is_valid=True,
+            flags=(),
+        )
+
+    def refine_evidence(
+        self,
+        query: ValidatedQuery,
+        evidence: EvidenceSet,
+    ) -> EvidenceSet:
+        return evidence
+
+
+class TestQueryValidatorProtocol:
+    def test_isinstance_check(self) -> None:
+        val = _MockQueryValidator()
+        assert isinstance(val, QueryValidator)
+
+    def test_validate_returns_result(self) -> None:
+        val = _MockQueryValidator()
+        candidate = QueryCandidate(
+            candidate_id="qc_1",
+            unit_id="u1",
+            query="What does 10 CFR 50.46(b)(1) require?",
+            query_class=QueryClass.CITATION_LOOKUP,
+            source_citations=("10 CFR 50.46(b)(1)",),
+            evidence_span_ids=("u1_0",),
+        )
+        result = val.validate(candidate)
+        assert result.is_valid is True
+        assert result.candidate_id == "qc_1"
+
+    def test_refine_evidence_returns_evidence_set(self) -> None:
+        val = _MockQueryValidator()
+        vq = ValidatedQuery(
+            candidate_id="qc_1",
+            unit_id="u1",
+            query="Test?",
+            query_class=QueryClass.CITATION_LOOKUP,
+            source_citations=(),
+            evidence_span_ids=(),
+            difficulty="easy",
+            corpus_snapshot_id="snap1",
+        )
+        evidence = EvidenceSet(unit_id="u1")
+        result = val.refine_evidence(vq, evidence)
+        assert result.unit_id == "u1"


### PR DESCRIPTION
## Summary
- Add `QueryCandidate`, `ValidationResult`, `ValidatedQuery` frozen dataclasses to `benchmark.domain.models`
- Add `QueryGenerator` and `QueryValidator` runtime-checkable protocol ports
- Add benchmark pipeline operational runbook (`docs/operations/benchmark-pipeline-runbook.md`)

Closes #36
Closes #37
Closes #38
Closes #42

Part of #2

## Test plan
- [x] `make test` — 913 passed, 7 skipped (14 new tests)
- [x] `make lint` — all checks passed
- [x] `make typecheck` — no new errors (pre-existing torch/transformers stubs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)